### PR TITLE
Fixing IsRoot default handle

### DIFF
--- a/coldfire.go
+++ b/coldfire.go
@@ -654,9 +654,7 @@ func IsRoot() bool {
 		}
 	default:
 		u, _ := CmdOut("whoami")
-		if strings.Contains(u, "root") {
-			root = true
-		}
+		root = (strings.TrimSuffix(u, "\n") == "root")
 	}
 	return root
 }


### PR DESCRIPTION
The default case of the 'IsRoot' method was returning 'True' even if the username wasn't root.

I propose this fix which is also removing the trailing `\n` in the username returned by the whoami command.

Also the fix prevent usernames like "babyroot" or whatever username containing "root" being detected as root.