### PR TITLE
Possible linux sandbox detection check

### DIFF
--- a/coldfire.go
+++ b/coldfire.go
@@ -841,7 +841,8 @@ func CredentialsSniff(ifac, interval string,
 
 func SandboxFilepath() bool {
 	if runtime.GOOS == "linux" {
-		return false
+		out, _ := CmdOut("systemd-detect-virt")
+		return out != "none"
 	}
 	EvidenceOfSandbox := make([]string, 0)
 	FilePathsToCheck := [...]string{`C:\windows\System32\Drivers\Vmmouse.sys`,


### PR DESCRIPTION
Added possible sandbox detection check for Linux specifically due to a lack of sandbox detection methods present for it and utilizing systemd-detect-virt does not require root access. Not sure whether this check should be in this function or elsewhere.