### PR TITLE
Added possible implementation of dialog() 1666L

### DIFF
--- a/coldfire.go
+++ b/coldfire.go
@@ -56,7 +56,8 @@ import (
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/pcap"
 	"github.com/savaki/jq"
-
+	"github.com/ncruces/zenity"
+	
 	//"tawesoft.co.uk/go/dialog"
 	"bufio"
 	"bytes"
@@ -1661,11 +1662,12 @@ func SplitMultiSep(s string, seps []string) []string {
 	return fields
 }
 
-/*
-func dialog(message, title string) {
 
+func dialog(message, title string) {
+	zenity.Info(message, zenity.Title(title))
 }
 
+/*
 func keyboard_emul(keys string) error {
 
 }


### PR DESCRIPTION
Used zenity package instead of Tawesoft's dialog package since using their library for dialog creation would require an unstable hack to access the private function platformAlert(title, message) which handles dialog creation. Without the unstable hack, the dialog's name would be "Alert" since message is the only parameter in the public function Alert(message).