### PR TITLE
Fixed ReadFile() errors

### DIFF
--- a/coldfire.go
+++ b/coldfire.go
@@ -16,6 +16,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"log"
 	"math/rand"
 	"net"
@@ -536,7 +537,7 @@ func ReadFile(filename string) (string, error) {
 	}
 	defer fil.Close()
 
-	b, err := io.ReadAll(fil)
+	b, err := ioutil.ReadAll(fil)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
The code was not working because the ReadAll function is not present in io but in io/ioutil